### PR TITLE
Enhance homepage with dark mode and new sections

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -6,6 +6,11 @@ body {
   padding: 0;
 }
 
+.dark-mode {
+  background-color: #121212;
+  color: #ffffff;
+}
+
 /* Navbar Customization */
 .navbar {
   background: linear-gradient(to right, #1a1a1a, #333);
@@ -28,6 +33,40 @@ body {
 .navbar-nav .nav-link:hover {
   color: #28a745 !important;
   transform: scale(1.1);
+}
+
+.dark-mode .navbar {
+  background: #000;
+}
+
+.dark-mode .navbar-nav .nav-link {
+  color: #fff !important;
+}
+
+.dark-mode .hero-section {
+  background: #1f1f1f;
+}
+
+.dark-mode .competitions-section,
+.dark-mode .learning-resources,
+.dark-mode .statistics-section {
+  background: #1e1e1e;
+  color: #fff;
+}
+
+.dark-mode .list-group-item {
+  background: #2a2a2a;
+  border-color: #28a745;
+  color: #fff;
+}
+
+.dark-mode .list-group-item:hover {
+  background: #333;
+}
+
+.dark-mode .community-section,
+.dark-mode .footer {
+  background: #000;
 }
 
 /* Hero Section */
@@ -182,6 +221,45 @@ body {
 .statistics-section h3 {
   font-size: 2rem;
   color: #28a745;
+}
+
+/* News Section */
+.news-section {
+  background: #fff;
+  padding: 50px;
+  border-radius: 10px;
+  box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.1);
+}
+
+.news-card {
+  border: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.dark-mode .news-section {
+  background: #1e1e1e;
+}
+
+.dark-mode .news-card {
+  background: #2a2a2a;
+  color: #fff;
+}
+
+/* Contact Section */
+.contact-section {
+  background: linear-gradient(to right, #ffffff, #f9f9f9);
+  padding: 50px;
+  border-radius: 10px;
+  box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.1);
+}
+
+.dark-mode .contact-section {
+  background: #1e1e1e;
+}
+
+.contact-section input,
+.contact-section textarea {
+  margin-bottom: 15px;
 }
 
 /* Footer */

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import "bootstrap/dist/css/bootstrap.min.css";
 
 function App() {
+  const [darkMode, setDarkMode] = useState(false);
+
   return (
-    <div className="app-container">
+    <div className={`app-container ${darkMode ? "dark-mode" : ""}`}>
       {/* Navigation Bar */}
       <nav className="navbar navbar-expand-lg navbar-dark bg-dark shadow-sm">
         <div className="container">
@@ -24,6 +26,12 @@ function App() {
               <li className="nav-item"><a className="nav-link" href="#">Community</a></li>
               <li className="nav-item"><a className="nav-link" href="#">Statistics</a></li>
             </ul>
+            <button
+              className="btn btn-outline-success ms-3"
+              onClick={() => setDarkMode(!darkMode)}
+            >
+              {darkMode ? "Light Mode" : "Dark Mode"}
+            </button>
           </div>
         </div>
       </nav>
@@ -43,6 +51,46 @@ function App() {
           <li className="list-group-item">DrivenData - Predicting Disease Spread</li>
           <li className="list-group-item">AI Blitz - Image Classification Challenge</li>
         </ul>
+      </section>
+
+      {/* Latest News */}
+      <section className="news-section container mt-5">
+        <h2 className="text-center fw-bold">Latest News</h2>
+        <div className="row">
+          <div className="col-md-4 mb-3">
+            <div className="card news-card h-100">
+              <div className="card-body">
+                <h5 className="card-title">Deep Learning Breakthroughs</h5>
+                <p className="card-text">
+                  Researchers unveil new techniques boosting model accuracy in image recognition tasks.
+                </p>
+                <a href="#" className="btn btn-success btn-sm">Read More</a>
+              </div>
+            </div>
+          </div>
+          <div className="col-md-4 mb-3">
+            <div className="card news-card h-100">
+              <div className="card-body">
+                <h5 className="card-title">Kaggle Releases New Dataset</h5>
+                <p className="card-text">
+                  Explore the latest open-source dataset for natural language processing enthusiasts.
+                </p>
+                <a href="#" className="btn btn-success btn-sm">Read More</a>
+              </div>
+            </div>
+          </div>
+          <div className="col-md-4 mb-3">
+            <div className="card news-card h-100">
+              <div className="card-body">
+                <h5 className="card-title">Community Events</h5>
+                <p className="card-text">
+                  Join upcoming webinars and workshops hosted by leading data scientists around the globe.
+                </p>
+                <a href="#" className="btn btn-success btn-sm">Read More</a>
+              </div>
+            </div>
+          </div>
+        </div>
       </section>
 
       {/* Learning Resources */}
@@ -81,6 +129,27 @@ function App() {
           <button className="btn btn-primary">Join Discord</button>
           <button className="btn btn-success ms-3">Follow on Twitter</button>
         </div>
+      </section>
+
+      {/* Contact Section */}
+      <section className="contact-section container mt-5">
+        <h2 className="text-center fw-bold">Get in Touch</h2>
+        <form className="mt-3">
+          <div className="row">
+            <div className="col-md-6">
+              <input type="text" className="form-control" placeholder="Name" />
+            </div>
+            <div className="col-md-6 mt-3 mt-md-0">
+              <input type="email" className="form-control" placeholder="Email" />
+            </div>
+          </div>
+          <div className="mt-3">
+            <textarea className="form-control" rows="4" placeholder="Message"></textarea>
+          </div>
+          <div className="text-center mt-3">
+            <button type="submit" className="btn btn-success">Send Message</button>
+          </div>
+        </form>
       </section>
 
       {/* Statistics Section */}


### PR DESCRIPTION
## Summary
- add dark mode support via navbar toggle
- include Latest News and Contact sections
- add styles for dark mode and new content

## Testing
- `npm test --silent -- -t 'renders learn react link'` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688513165d5883338dcdf693f0c3beb7